### PR TITLE
fix: handle one repo failing causing the whole loop to break

### DIFF
--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 96.6%</title>
+    <title>interrogate: 95.9%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">96.6%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">96.6%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">95.9%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">95.9%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/src/sw_metadata_bot/pipeline.py
+++ b/src/sw_metadata_bot/pipeline.py
@@ -187,40 +187,86 @@ def run_pipeline(
         except Exception:
             current_commit_id = None
 
-        reused_previous = False
-        if not force_analysis and (
-            previous_snapshot_root is not None
-            and previous_record is not None
-            and previous_commit_id
-            and current_commit_id
-            and previous_commit_id != "Unknown"
-            and current_commit_id != "Unknown"
-            and current_commit_id == previous_commit_id
-        ):
-            previous_repo_folder = previous_snapshot_root / sanitize_repo_name(repo_url)
-            if previous_repo_folder.exists():
-                analysis_runtime.copy_previous_repo_artifacts(
-                    previous_repo_folder, repo_folder
+        try:
+            reused_previous = False
+            if not force_analysis and (
+                previous_snapshot_root is not None
+                and previous_record is not None
+                and previous_commit_id
+                and current_commit_id
+                and previous_commit_id != "Unknown"
+                and current_commit_id != "Unknown"
+                and current_commit_id == previous_commit_id
+            ):
+                previous_repo_folder = previous_snapshot_root / sanitize_repo_name(
+                    repo_url
                 )
-                reused_previous = True
+                if previous_repo_folder.exists():
+                    analysis_runtime.copy_previous_repo_artifacts(
+                        previous_repo_folder, repo_folder
+                    )
+                    reused_previous = True
 
-        if not reused_previous:
-            analysis_runtime.run_metacheck_for_repo(
-                repo_url,
+            if not reused_previous:
+                analysis_runtime.run_metacheck_for_repo(
+                    repo_url,
+                    repo_folder,
+                    generate_codemeta_if_missing=generate_codemeta_if_missing,
+                )
+
+            normalized_repo = analysis_runtime.normalize_repo_url(repo_url)
+            if normalized_repo in opt_out_repos:
+                record = build_record_entry(
+                    run_root=run_root,
+                    repo_url=repo_url,
+                    platform=analysis_runtime.detect_repo_platform(repo_url),
+                    analysis=RecordAnalysis(
+                        analysis_date=datetime.now(timezone.utc).strftime(
+                            "%Y-%m-%dT%H:%M:%SZ"
+                        ),
+                        bot_version=__version__,
+                        rsmetacheck_version="unknown",
+                        pitfalls_count=0,
+                        warnings_count=0,
+                        pitfalls_ids=[],
+                        warnings_ids=[],
+                    ),
+                    lifecycle=RecordLifecycle(
+                        action="skipped",
+                        reason_code="in_opt_out_list",
+                        current_commit_id=current_commit_id,
+                        dry_run=dry_run,
+                        issue_persistence="none",
+                        file_path=repo_folder / "pitfall.jsonld",
+                    ),
+                )
+            else:
+                record = analysis_runtime.create_analysis_record(
+                    run_root=run_root,
+                    repo_url=repo_url,
+                    repo_folder=repo_folder,
+                    previous_record=previous_record,
+                    current_commit_id=current_commit_id,
+                    dry_run=dry_run,
+                    custom_message=custom_message,
+                    force_analysis=force_analysis,
+                )
+
+            analysis_runtime.write_analysis_repo_report(
                 repo_folder,
-                generate_codemeta_if_missing=generate_codemeta_if_missing,
+                record,
+                dry_run=dry_run,
+                run_root=run_root,
+                analysis_summary_file=analysis_report_path,
+                previous_report=resolved_previous_report,
             )
-
-        normalized_repo = analysis_runtime.normalize_repo_url(repo_url)
-        if normalized_repo in opt_out_repos:
+        except Exception as exc:
             record = build_record_entry(
                 run_root=run_root,
                 repo_url=repo_url,
                 platform=analysis_runtime.detect_repo_platform(repo_url),
                 analysis=RecordAnalysis(
-                    analysis_date=datetime.now(timezone.utc).strftime(
-                        "%Y-%m-%dT%H:%M:%SZ"
-                    ),
+                    analysis_date="unknown",
                     bot_version=__version__,
                     rsmetacheck_version="unknown",
                     pitfalls_count=0,
@@ -229,34 +275,34 @@ def run_pipeline(
                     warnings_ids=[],
                 ),
                 lifecycle=RecordLifecycle(
-                    action="skipped",
-                    reason_code="in_opt_out_list",
+                    action="failed",
+                    reason_code="exception",
+                    findings_signature="",
                     current_commit_id=current_commit_id,
+                    previous_commit_id=(
+                        analysis_runtime.extract_previous_commit(previous_record)
+                        if previous_record is not None
+                        else None
+                    ),
                     dry_run=dry_run,
                     issue_persistence="none",
-                    file_path=repo_folder / "pitfall.jsonld",
+                    issue_url=None,
+                    file_path=repo_folder / constants.FILENAME_PITFALL,
+                    error=str(exc),
                 ),
             )
-        else:
-            record = analysis_runtime.create_analysis_record(
-                run_root=run_root,
-                repo_url=repo_url,
-                repo_folder=repo_folder,
-                previous_record=previous_record,
-                current_commit_id=current_commit_id,
-                dry_run=dry_run,
-                custom_message=custom_message,
-                force_analysis=force_analysis,
-            )
+            try:
+                analysis_runtime.write_analysis_repo_report(
+                    repo_folder,
+                    record,
+                    dry_run=dry_run,
+                    run_root=run_root,
+                    analysis_summary_file=analysis_report_path,
+                    previous_report=resolved_previous_report,
+                )
+            except Exception:
+                pass
 
-        analysis_runtime.write_analysis_repo_report(
-            repo_folder,
-            record,
-            dry_run=dry_run,
-            run_root=run_root,
-            analysis_summary_file=analysis_report_path,
-            previous_report=resolved_previous_report,
-        )
         run_records.append(record)
 
         evaluated_repositories[sanitize_repo_name(repo_url)] = {

--- a/src/sw_metadata_bot/publish.py
+++ b/src/sw_metadata_bot/publish.py
@@ -301,118 +301,40 @@ def publish_analysis(
             updated_records.append(record)
             continue
 
-        action = str(record.get("action", ""))
-        platform = _detect_platform_for_publish(repo_url, record)
-        issue_url = _issue_url_for_publish(record)
-
-        if action == constants.ACTION_SKIPPED and issue_url:
-            issue_client = issue_client_for_platform(platform)
-            comments = issue_client.get_issue_comments(issue_url)
-            unsubscribe_detected = any(
-                _is_unsubscribe_comment(comment) for comment in comments
-            )
-            record["unsubscribe_detected"] = unsubscribe_detected
-            if unsubscribe_detected:
-                config_file = analysis_root / constants.FILENAME_CONFIG_SNAPSHOT
-                if config_file.exists():
-                    append_opt_out_to_config(config_file, repo_url, explicit=False)
-
-                if input_config_file is not None:
-                    original_input_path = input_config_file
-                    if not original_input_path.is_absolute():
-                        original_input_path = analysis_root.parent / original_input_path
-                    if original_input_path.exists():
-                        append_opt_out_to_config(
-                            original_input_path, repo_url, explicit=False
-                        )
-
-                record["action"] = constants.ACTION_SKIPPED
-                record["reason_code"] = constants.REASON_CODE_UNSUBSCRIBE
-                record["dry_run"] = False
-                record["issue_persistence"] = "none"
-                record.pop("simulated_issue_url", None)
-                updated_records.append(record)
-                _write_per_repo_report(
-                    analysis_root,
-                    record,
-                    analysis_summary_file,
-                    previous_report,
-                )
-                continue
-
-        if (
-            record.get("dry_run") is False
-            and record.get("action") != constants.ACTION_FAILED
-        ):
-            skipped_published += 1
-            updated_records.append(record)
-            continue
-
-        if action == constants.ACTION_FAILED:
-            if not retry_failed:
-                skipped_failed_retry += 1
-                updated_records.append(record)
-                continue
-
-            if not _can_retry_failed_record(record):
-                skipped_failed_retry += 1
-                updated_records.append(record)
-                continue
-
-            retry_action = _resolve_retry_action(record)
-            if retry_action is None:
-                skipped_failed_retry += 1
-                record["reason_code"] = "missing_retry_action"
-                updated_records.append(record)
-                continue
-
-            action = retry_action
-            record["action"] = retry_action
-
-        platform = _detect_platform_for_publish(repo_url, record)
-        issue_url = _issue_url_for_publish(record)
-        attempted_action = action
-
         try:
-            if action in {constants.ACTION_UPDATED_BY_COMMENT, constants.ACTION_CLOSED}:
-                if not issue_url:
-                    raise click.ClickException(
-                        f"Missing issue URL for publish action {action}: {repo_url}"
-                    )
+            action = str(record.get("action", ""))
+            platform = _detect_platform_for_publish(repo_url, record)
+            issue_url = _issue_url_for_publish(record)
 
+            if action == constants.ACTION_SKIPPED and issue_url:
                 issue_client = issue_client_for_platform(platform)
                 comments = issue_client.get_issue_comments(issue_url)
                 unsubscribe_detected = any(
                     _is_unsubscribe_comment(comment) for comment in comments
                 )
+                record["unsubscribe_detected"] = unsubscribe_detected
                 if unsubscribe_detected:
-                    # update config of analysis snapshot when present
                     config_file = analysis_root / constants.FILENAME_CONFIG_SNAPSHOT
                     if config_file.exists():
                         append_opt_out_to_config(config_file, repo_url, explicit=False)
 
-                    # also update the original input config file when available
-                    input_config_value = run_metadata.get("input_config_file")
-                    if isinstance(input_config_value, str):
-                        input_config_path = Path(input_config_value)
-                        if not input_config_path.is_absolute():
-                            input_config_path = analysis_root.parent / input_config_path
-                        if input_config_path.exists():
+                    if input_config_file is not None:
+                        original_input_path = input_config_file
+                        if not original_input_path.is_absolute():
+                            original_input_path = (
+                                analysis_root.parent / original_input_path
+                            )
+                        if original_input_path.exists():
                             append_opt_out_to_config(
-                                input_config_path, repo_url, explicit=False
+                                original_input_path, repo_url, explicit=False
                             )
 
-                    # skip publish
                     record["action"] = constants.ACTION_SKIPPED
                     record["reason_code"] = constants.REASON_CODE_UNSUBSCRIBE
-                    record["unsubscribe_detected"] = True
                     record["dry_run"] = False
                     record["issue_persistence"] = "none"
                     record.pop("simulated_issue_url", None)
                     updated_records.append(record)
-                    analysis_summary_value = run_report.get("run_metadata", {}).get(
-                        "analysis_summary_file"
-                    )
                     _write_per_repo_report(
                         analysis_root,
                         record,
@@ -421,83 +343,194 @@ def publish_analysis(
                     )
                     continue
 
-                issue_data = issue_client.get_issue(issue_url)
-                if action == constants.ACTION_UPDATED_BY_COMMENT and _issue_is_closed(
-                    issue_data
-                ):
-                    record["action"] = constants.ACTION_SIMULATED_CREATED
-                    record["reason_code"] = "changed_and_issue_closed"
-                    record["previous_issue_url"] = issue_url
-                    record.pop("issue_url", None)
-                    action = constants.ACTION_SIMULATED_CREATED
+            if (
+                record.get("dry_run") is False
+                and record.get("action") != constants.ACTION_FAILED
+            ):
+                skipped_published += 1
+                updated_records.append(record)
+                continue
 
-            if action == constants.ACTION_SIMULATED_CREATED:
-                body = _load_publish_body(analysis_root, repo_url)
-                title = "Automated Metadata Quality Report from CodeMetaSoft"
-                issue_client = issue_client_for_platform(platform)
-                created_url = issue_client.create_issue(repo_url, title, body)
-
-                record["action"] = constants.ACTION_CREATED
-                record["issue_url"] = created_url
-                record["dry_run"] = False
-                record["issue_persistence"] = "posted"
-                record.pop("simulated_issue_url", None)
-                _clear_failure_metadata(record)
-
-            elif action == constants.ACTION_UPDATED_BY_COMMENT:
-                if not issue_url:
-                    raise click.ClickException(
-                        f"Missing previous issue URL for repo: {repo_url}"
-                    )
-
-                body = _load_publish_body(analysis_root, repo_url)
-                issue_client = issue_client_for_platform(platform)
-                issue_client.add_issue_comment(
-                    issue_url,
-                    f"New analysis detected updated findings.\n\n{body}",
-                )
-
-                record["issue_url"] = issue_url
-                record["dry_run"] = False
-                record["issue_persistence"] = "posted"
-                record.pop("simulated_issue_url", None)
-                _clear_failure_metadata(record)
-
-            elif action == constants.ACTION_CLOSED:
-                if not issue_url:
-                    raise click.ClickException(
-                        f"Missing previous issue URL for repo: {repo_url}"
-                    )
-
-                issue_client = issue_client_for_platform(platform)
-                issue_client.add_issue_comment(
-                    issue_url,
-                    "The latest analysis no longer reports metadata pitfalls/warnings. "
-                    "Closing this issue.",
-                )
-                issue_client.close_issue(issue_url)
-
-                record["issue_url"] = issue_url
-                record["previous_issue_state"] = "closed"
-                record["dry_run"] = False
-                record["issue_persistence"] = "posted"
-                record.pop("simulated_issue_url", None)
-                _clear_failure_metadata(record)
-
-            elif action == constants.ACTION_SKIPPED:
-                record["dry_run"] = False
-                record["issue_persistence"] = "none"
-                record.pop("simulated_issue_url", None)
-                _clear_failure_metadata(record)
-
-            else:
-                if attempted_action == constants.ACTION_FAILED:
+            if action == constants.ACTION_FAILED:
+                if not retry_failed:
                     skipped_failed_retry += 1
-                else:
+                    updated_records.append(record)
+                    continue
+
+                if not _can_retry_failed_record(record):
+                    skipped_failed_retry += 1
+                    updated_records.append(record)
+                    continue
+
+                retry_action = _resolve_retry_action(record)
+                if retry_action is None:
+                    skipped_failed_retry += 1
+                    record["reason_code"] = "missing_retry_action"
+                    updated_records.append(record)
+                    continue
+
+                action = retry_action
+                record["action"] = retry_action
+
+            platform = _detect_platform_for_publish(repo_url, record)
+            issue_url = _issue_url_for_publish(record)
+            attempted_action = action
+
+            try:
+                if action in {
+                    constants.ACTION_UPDATED_BY_COMMENT,
+                    constants.ACTION_CLOSED,
+                }:
+                    if not issue_url:
+                        raise click.ClickException(
+                            f"Missing issue URL for publish action {action}: {repo_url}"
+                        )
+
+                    issue_client = issue_client_for_platform(platform)
+                    comments = issue_client.get_issue_comments(issue_url)
+                    unsubscribe_detected = any(
+                        _is_unsubscribe_comment(comment) for comment in comments
+                    )
+                    if unsubscribe_detected:
+                        # update config of analysis snapshot when present
+                        config_file = analysis_root / constants.FILENAME_CONFIG_SNAPSHOT
+                        if config_file.exists():
+                            append_opt_out_to_config(
+                                config_file, repo_url, explicit=False
+                            )
+
+                        # also update the original input config file when available
+                        input_config_value = run_metadata.get("input_config_file")
+                        if isinstance(input_config_value, str):
+                            input_config_path = Path(input_config_value)
+                            if not input_config_path.is_absolute():
+                                input_config_path = (
+                                    analysis_root.parent / input_config_path
+                                )
+                            if input_config_path.exists():
+                                append_opt_out_to_config(
+                                    input_config_path, repo_url, explicit=False
+                                )
+
+                        # skip publish
+                        record["action"] = constants.ACTION_SKIPPED
+                        record["reason_code"] = constants.REASON_CODE_UNSUBSCRIBE
+                        record["unsubscribe_detected"] = True
+                        record["dry_run"] = False
+                        record["issue_persistence"] = "none"
+                        record.pop("simulated_issue_url", None)
+                        updated_records.append(record)
+                        analysis_summary_value = run_report.get("run_metadata", {}).get(
+                            "analysis_summary_file"
+                        )
+                        _write_per_repo_report(
+                            analysis_root,
+                            record,
+                            analysis_summary_file,
+                            previous_report,
+                        )
+                        continue
+
+                    issue_data = issue_client.get_issue(issue_url)
+                    if (
+                        action == constants.ACTION_UPDATED_BY_COMMENT
+                        and _issue_is_closed(issue_data)
+                    ):
+                        record["action"] = constants.ACTION_SIMULATED_CREATED
+                        record["reason_code"] = "changed_and_issue_closed"
+                        record["previous_issue_url"] = issue_url
+                        record.pop("issue_url", None)
+                        action = constants.ACTION_SIMULATED_CREATED
+
+                if action == constants.ACTION_SIMULATED_CREATED:
+                    body = _load_publish_body(analysis_root, repo_url)
+                    title = "Automated Metadata Quality Report from CodeMetaSoft"
+                    issue_client = issue_client_for_platform(platform)
+                    created_url = issue_client.create_issue(repo_url, title, body)
+
+                    record["action"] = constants.ACTION_CREATED
+                    record["issue_url"] = created_url
                     record["dry_run"] = False
+                    record["issue_persistence"] = "posted"
                     record.pop("simulated_issue_url", None)
                     _clear_failure_metadata(record)
 
+                elif action == constants.ACTION_UPDATED_BY_COMMENT:
+                    if not issue_url:
+                        raise click.ClickException(
+                            f"Missing previous issue URL for repo: {repo_url}"
+                        )
+
+                    body = _load_publish_body(analysis_root, repo_url)
+                    issue_client = issue_client_for_platform(platform)
+                    issue_client.add_issue_comment(
+                        issue_url,
+                        f"New analysis detected updated findings.\n\n{body}",
+                    )
+
+                    record["issue_url"] = issue_url
+                    record["dry_run"] = False
+                    record["issue_persistence"] = "posted"
+                    record.pop("simulated_issue_url", None)
+                    _clear_failure_metadata(record)
+
+                elif action == constants.ACTION_CLOSED:
+                    if not issue_url:
+                        raise click.ClickException(
+                            f"Missing previous issue URL for repo: {repo_url}"
+                        )
+
+                    issue_client = issue_client_for_platform(platform)
+                    issue_client.add_issue_comment(
+                        issue_url,
+                        "The latest analysis no longer reports metadata pitfalls/warnings. "
+                        "Closing this issue.",
+                    )
+                    issue_client.close_issue(issue_url)
+
+                    record["issue_url"] = issue_url
+                    record["previous_issue_state"] = "closed"
+                    record["dry_run"] = False
+                    record["issue_persistence"] = "posted"
+                    record.pop("simulated_issue_url", None)
+                    _clear_failure_metadata(record)
+
+                elif action == constants.ACTION_SKIPPED:
+                    record["dry_run"] = False
+                    record["issue_persistence"] = "none"
+                    record.pop("simulated_issue_url", None)
+                    _clear_failure_metadata(record)
+
+                else:
+                    if attempted_action == constants.ACTION_FAILED:
+                        skipped_failed_retry += 1
+                    else:
+                        record["dry_run"] = False
+                        record.pop("simulated_issue_url", None)
+                        _clear_failure_metadata(record)
+
+            except Exception as exc:
+                record["action"] = constants.ACTION_FAILED
+                record["reason_code"] = constants.REASON_CODE_PUBLISH_EXCEPTION
+                error_text = str(exc)
+                record["error"] = error_text
+                record["dry_run"] = True
+                record["is_transient_error"] = _is_transient_publish_error(error_text)
+                record["retry_after_seconds"] = _retry_after_seconds_from_error(
+                    error_text
+                )
+                previous_retry_attempt = record.get("retry_attempt")
+                retry_attempt = (
+                    previous_retry_attempt + 1
+                    if isinstance(previous_retry_attempt, int)
+                    else 1
+                )
+                record["retry_attempt"] = retry_attempt
+                record["failed_at"] = _now_utc_iso()
+                if attempted_action and attempted_action != constants.ACTION_FAILED:
+                    record["last_publish_action"] = attempted_action
+
+            updated_records.append(record)
         except Exception as exc:
             record["action"] = constants.ACTION_FAILED
             record["reason_code"] = constants.REASON_CODE_PUBLISH_EXCEPTION
@@ -514,10 +547,7 @@ def publish_analysis(
             )
             record["retry_attempt"] = retry_attempt
             record["failed_at"] = _now_utc_iso()
-            if attempted_action and attempted_action != constants.ACTION_FAILED:
-                record["last_publish_action"] = attempted_action
-
-        updated_records.append(record)
+            updated_records.append(record)
         _write_per_repo_report(
             analysis_root,
             record,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from sw_metadata_bot import analysis_runtime, commit_lookup, pipeline
+from sw_metadata_bot import analysis_runtime, commit_lookup, constants, pipeline
 from sw_metadata_bot import publish as publish_module
 from sw_metadata_bot.config.schemas import BotConfig
 
@@ -297,6 +297,89 @@ def test_run_pipeline_invokes_rsmetacheck_and_writes_reports(monkeypatch, tmp_pa
         run_report["records"][0]["file"]
         == "202603/github_com_example_repo/pitfall.jsonld"
     )
+
+
+def test_run_pipeline_continues_when_one_repo_analysis_fails(monkeypatch, tmp_path):
+    """The pipeline continues processing other repos even if one repo fails."""
+
+    def fake_run_metacheck_for_repo(
+        repo_url, repo_folder, generate_codemeta_if_missing
+    ):
+        if "fail" in repo_url:
+            raise RuntimeError("analysis failure")
+        repo_folder.mkdir(parents=True, exist_ok=True)
+        (repo_folder / constants.FILENAME_PITFALL).write_text(
+            json.dumps({"@type": "FailureReport"}), encoding="utf-8"
+        )
+
+    def fake_create_analysis_record(
+        *,
+        run_root,
+        repo_url,
+        repo_folder,
+        previous_record,
+        current_commit_id,
+        dry_run,
+        custom_message,
+        force_analysis=False,
+    ):
+        return {
+            "repo_url": repo_url,
+            "action": "simulated_created",
+            "platform": "github",
+            "dry_run": dry_run,
+            "issue_persistence": "simulated",
+            "file": str(repo_folder / constants.FILENAME_PITFALL),
+        }
+
+    monkeypatch.setattr(
+        analysis_runtime, "run_metacheck_for_repo", fake_run_metacheck_for_repo
+    )
+    monkeypatch.setattr(
+        analysis_runtime, "create_analysis_record", fake_create_analysis_record
+    )
+
+    output_root = tmp_path / "outputs"
+    config_path = _write_config(
+        tmp_path,
+        analysis={
+            "repositories": [
+                "https://github.com/example/repo-fail",
+                "https://github.com/example/repo-ok",
+            ]
+        },
+        outputs={
+            "output_root_dir": str(output_root),
+            "run_name": "batch-a",
+            "snapshot_tag_format": None,
+        },
+    )
+
+    pipeline.run_pipeline(
+        config_file=config_path,
+        dry_run=True,
+        snapshot_tag="202603",
+        previous_report=None,
+    )
+
+    run_report_path = output_root / "batch-a" / "202603" / "run_report.json"
+    assert run_report_path.exists()
+    run_report = json.loads(run_report_path.read_text())
+
+    failed_record = next(
+        record
+        for record in run_report["records"]
+        if record["repo_url"] == "https://github.com/example/repo-fail"
+    )
+    assert failed_record["action"] == "failed"
+    assert failed_record["reason_code"] == "exception"
+
+    success_record = next(
+        record
+        for record in run_report["records"]
+        if record["repo_url"] == "https://github.com/example/repo-ok"
+    )
+    assert success_record["action"] == "simulated_created"
 
 
 def test_run_pipeline_marks_run_report_dry_run(monkeypatch, tmp_path):

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -601,6 +601,61 @@ def test_publish_api_error_marks_record_as_failed(tmp_path, monkeypatch):
     assert record["last_publish_action"] == "simulated_created"
 
 
+def test_publish_unknown_platform_marks_record_failed_and_continues(
+    tmp_path, monkeypatch
+):
+    """publish records unsupported platforms as failed but continues processing."""
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    repo_url_unsupported = "https://example.com/repo"
+    repo_url_github = "https://github.com/example/repo"
+
+    _write_run_report(
+        snapshot_dir,
+        records=[
+            {
+                "repo_url": repo_url_unsupported,
+                "action": "simulated_created",
+                "dry_run": True,
+                "issue_persistence": "simulated",
+            },
+            {
+                "repo_url": repo_url_github,
+                "action": "simulated_created",
+                "platform": "github",
+                "dry_run": True,
+                "issue_persistence": "simulated",
+            },
+        ],
+    )
+    _write_issue_report(snapshot_dir, repo_url_github)
+
+    fake = _FakeIssueClient()
+    _patch_clients(monkeypatch, fake)
+
+    runner = CliRunner()
+    result = runner.invoke(publish_command, ["--analysis-root", str(snapshot_dir)])
+
+    assert result.exit_code == 0, result.output
+
+    report = json.loads((snapshot_dir / "run_report.json").read_text())
+    failed_record = next(
+        record
+        for record in report["records"]
+        if record["repo_url"] == repo_url_unsupported
+    )
+    success_record = next(
+        record for record in report["records"] if record["repo_url"] == repo_url_github
+    )
+
+    assert failed_record["action"] == "failed"
+    assert failed_record["reason_code"] == "publish_exception"
+    assert "Unsupported platform" in failed_record["error"]
+
+    assert success_record["action"] == "created"
+    assert success_record["issue_url"] == f"{repo_url_github}/issues/99"
+
+
 def test_publish_failed_record_not_retried_without_flag(tmp_path, monkeypatch):
     """publish keeps failed records untouched unless --retry-failed is set."""
     snapshot_dir = tmp_path / "snapshot"


### PR DESCRIPTION
handle cases where one repo in the list analysis or publish fails. It now report that this repo has fail and resume processing the rest of the list.