### PR TITLE
fix: handles gilab nested group url

### DIFF
--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 97.7%</title>
+    <title>interrogate: 100%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">97.7%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">97.7%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330" data-interrogate="result">100%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="330" data-interrogate="result">100%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/src/sw_metadata_bot/gitlab_api.py
+++ b/src/sw_metadata_bot/gitlab_api.py
@@ -24,10 +24,12 @@ class GitLabAPI(IssueAPIBase):
     @staticmethod
     def parse_repo_url(url: str) -> tuple[str, str, str]:
         """
-        Parse GitLab URL to extract host, owner, and repo.
+        Parse GitLab URL to extract host, namespace, and repo.
+
+        The namespace can be a single owner or a nested group path.
 
         Returns:
-            Tuple of (host, owner, repo_name)
+            Tuple of (host, namespace, repo_name)
         """
         parsed = urlparse(url)
         host = parsed.netloc
@@ -35,12 +37,13 @@ class GitLabAPI(IssueAPIBase):
         if not host or "gitlab" not in host.lower():
             raise ValueError(f"Not a GitLab URL: {url}")
 
-        parts = parsed.path.strip("/").split("/")
+        parts = [part for part in parsed.path.split("/") if part]
         if len(parts) < 2:
             raise ValueError(f"Invalid GitLab URL format: {url}")
 
-        owner, repo = parts[0], parts[1].removesuffix(".git")
-        return host, owner, repo
+        namespace = "/".join(parts[:-1])
+        repo = parts[-1].removesuffix(".git")
+        return host, namespace, repo
 
     def get_base_url(self, host: str) -> str:
         """Get API base URL for GitLab host."""
@@ -169,11 +172,11 @@ class GitLabAPI(IssueAPIBase):
         Returns:
             URL of created issue (or fake URL in dry-run mode)
         """
-        host, owner, repo = self.parse_repo_url(repo_url)
-        project_id = f"{owner}/{repo}"
+        host, namespace, repo = self.parse_repo_url(repo_url)
+        project_id = f"{namespace}/{repo}"
 
         if self.dry_run:
-            return f"https://{host}/{owner}/{repo}/-/issues/0"
+            return f"https://{host}/{namespace}/{repo}/-/issues/0"
 
         base_url = self.get_base_url(host)
         url = f"{base_url}/projects/{requests.utils.quote(project_id, safe='')}/issues"

--- a/tests/test_gitlab_api.py
+++ b/tests/test_gitlab_api.py
@@ -1,0 +1,21 @@
+"""Unit tests for GitLab API helpers."""
+
+import pytest
+
+from sw_metadata_bot.gitlab_api import GitLabAPI
+
+
+@pytest.mark.parametrize(
+    ("repo_url", "expected_namespace"),
+    [
+        ("https://gitlab.com/owner/repo", "owner"),
+        ("https://gitlab.com/group/subgroup/repo", "group/subgroup"),
+    ],
+)
+def test_parse_repo_url_supports_single_and_nested_groups(repo_url, expected_namespace):
+    """Parse GitLab repository URLs with either a single owner or a nested group path."""
+    host, namespace, repo = GitLabAPI.parse_repo_url(repo_url)
+
+    assert host == "gitlab.com"
+    assert namespace == expected_namespace
+    assert repo == "repo"


### PR DESCRIPTION
fixes #126 

Gitlab.com can have a group in a valid repository url. That was not handled correclty in the Gitlab API part.

It is now fixed.